### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI - Tests & Security
+permissions:
+  contents: read
 
 # Tests the LLM Provider Abstraction system including:
 # - Provider Factory (Ollama & OpenAI providers)  


### PR DESCRIPTION
Potential fix for [https://github.com/mheadd/llm-persistent-instructions/security/code-scanning/2](https://github.com/mheadd/llm-persistent-instructions/security/code-scanning/2)

The best way to fix the issue is to explicitly declare the minimal set of permissions required for the workflow or job. Since neither job appears to require anything more than read access to repository contents (for actions like checkout and dependency scanning), we should add a `permissions` block set to `contents: read` at the workflow root. This will ensure all jobs do not have unnecessary write privileges. No functionality is changed and downstream jobs can still override if needed. The edit should be placed after the workflow `name`, before the `on:` key for root-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
